### PR TITLE
Fix/issue 77

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.4.0")
     implementation("com.google.android.material:material:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.google.android.gms:play-services-location:19.0.1")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.4.1")
     implementation("com.intuit.sdp:sdp-android:1.0.6")
     implementation("com.intuit.ssp:ssp-android:1.0.6")

--- a/locus/build.gradle.kts
+++ b/locus/build.gradle.kts
@@ -36,7 +36,7 @@ android {
 dependencies {
     compileOnly("com.google.android.material:material:1.4.0")
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib:1.6.21")
-    compileOnly("com.google.android.gms:play-services-location:19.0.1")
+    compileOnly("com.google.android.gms:play-services-location:21.0.1")
     implementation("androidx.appcompat:appcompat:1.4.0")
     implementation("androidx.activity:activity-ktx:1.4.0")
 }

--- a/locus/src/main/java/com/birjuvachhani/locus/LocationBroadcastReceiver.kt
+++ b/locus/src/main/java/com/birjuvachhani/locus/LocationBroadcastReceiver.kt
@@ -52,9 +52,11 @@ internal class LocationBroadcastReceiver : BroadcastReceiver() {
         intent ?: return
         if (intent.action == ACTION_PROCESS_UPDATES && LocationResult.hasResult(intent)) {
             LocationResult.extractResult(intent).let { result ->
-                if (result.locations.isNotEmpty()) {
-                    logDebug("Received location ${result.lastLocation}")
-                    locationLiveData.postValue(LocusResult.success(result.lastLocation))
+                if (result?.locations?.isNotEmpty() == true) {
+                    result.lastLocation?.let {
+                        logDebug("Received location $it")
+                        locationLiveData.postValue(LocusResult.success(it))
+                    }
                 }
             }
         }

--- a/locus/src/main/java/com/birjuvachhani/locus/LocationProvider.kt
+++ b/locus/src/main/java/com/birjuvachhani/locus/LocationProvider.kt
@@ -83,7 +83,7 @@ internal class LocationProvider(context: Context) {
         fun startUpdates() {
             val callback = object : LocationCallback() {
                 override fun onLocationResult(result: LocationResult) {
-                    result.lastLocation?.let { LocusResult.success(it) }?.let { onUpdate(it) }
+                    result.lastLocation?.let { onUpdate(LocusResult.success(it)) }
                     mFusedLocationProviderClient.removeLocationUpdates(this)
                 }
             }

--- a/locus/src/main/java/com/birjuvachhani/locus/LocationProvider.kt
+++ b/locus/src/main/java/com/birjuvachhani/locus/LocationProvider.kt
@@ -83,7 +83,7 @@ internal class LocationProvider(context: Context) {
         fun startUpdates() {
             val callback = object : LocationCallback() {
                 override fun onLocationResult(result: LocationResult) {
-                    onUpdate(LocusResult.success(result.lastLocation))
+                    result.lastLocation?.let { LocusResult.success(it) }?.let { onUpdate(it) }
                     mFusedLocationProviderClient.removeLocationUpdates(this)
                 }
             }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
The library has an issue with the Google Play Service Location 21.0.1 that crashes when the user requests to open the Location service. The issue has been resolved in this PR.

### Alternate Designs
Doesn't affect any design changes. It is just a bug fix (issue #77).

### Why Should This Be In Core?
To support the latest version of Google Play Service Location.

### Benefits
Bug fix in a newer Google Play Service Location version.

### Possible Drawbacks
Nothing

### Verification Process
At first, I updated the Google Play Service Location version and then test with the following process.
- Go to the device setting and turn off the location service.
- Go to the application and remove location permission.
- Run the application.
- Test it with all functionalities that appear in the design like:
    - Background Location Updates 
    - Force Background Updates 
    - Resolve Location Settings
    - Single Update 
    - Location Service 
- Start button to see the location update multiple times with different settings a mentioned above.
- Stop button to stop location update.

### Applicable Issues

